### PR TITLE
Also find inheritedType from property

### DIFF
--- a/LiteDB.FSharp/Json.fs
+++ b/LiteDB.FSharp/Json.fs
@@ -310,7 +310,11 @@ type FSharpJsonConverter() =
             let inheritedType = inheritedTypeQuickAccessor.GetOrAdd((t.FullName,jsonFields),fun (_,jsonFields) ->
                 let findType (jsonFields: seq<string>) =
                     inheritedTypes |> Seq.maxBy (fun tp ->
-                        let fields = tp.GetFields() |> Seq.map (fun fd -> fd.Name)
+                        let fields = 
+                            let properties = tp.GetProperties() |> Array.filter(fun prop -> prop.CanWrite) |> Array.map (fun prop -> prop.Name)
+                            if properties.Length > 0 then properties
+                            else
+                                tp.GetFields() |> Array.map (fun fd -> fd.Name)
                         let fieldsLength = Seq.length fields
                         (jsonFields |> Seq.filter(fun jsonField ->
                             Seq.contains jsonField fields


### PR DESCRIPTION
Before this PR
We only find registered inheritedType by fields
Now we can find registered inheritedType by properties
Comparing `object type`,
`CLIMutable Record type` generate a free constructor and equality
I am now using `CLIMutable Record type` more often
So i implement this