### PR TITLE
Fix datetime roundtrip, do not use AsDateTime directly

### DIFF
--- a/LiteDB.FSharp.Tests/Tests.Bson.fs
+++ b/LiteDB.FSharp.Tests/Tests.Bson.fs
@@ -121,7 +121,7 @@ let bsonConversions =
       | otherwise -> fail()
 
     testCase "records with DateTime" <| fun _ ->
-      let time = DateTime(2017, 10, 15)
+      let time = DateTime(2017, 10, 15, 10, 15, 0)
       let record = { id = 1; created = time }
       let doc = Bson.serialize record
       match Bson.deserialize<RecordWithDateTime> doc with
@@ -129,17 +129,23 @@ let bsonConversions =
           Expect.equal 2017 timeCreated.Year "Year is mapped correctly"
           Expect.equal 10 timeCreated.Month "Month is mapped correctly"
           Expect.equal 15 timeCreated.Day "Day is mapped correctly"
+          Expect.equal 10 timeCreated.Hour "Hour is mapped correctly"
+          Expect.equal 15 timeCreated.Minute "Minute is mapped correctly"
+          Expect.equal 0 timeCreated.Second "Second is mapped correctly"
       | otherwise -> fail()
 
 
     testCase "Bson.readDate works" <| fun _ ->
-      let time = DateTime(2017, 10, 15)
+      let time = DateTime(2017, 10, 15, 10, 15, 0)
       let record = { id = 1; created = time }
       let doc = Bson.serialize record
       let deserialized = Bson.readDate "created" doc
       Expect.equal time.Year deserialized.Year "Year is correctly read"
       Expect.equal time.Month deserialized.Month "Month is correctly read"
       Expect.equal time.Day deserialized.Day "Day is correctly read"
+      Expect.equal time.Hour deserialized.Hour "Hour is mapped correctly"
+      Expect.equal time.Minute deserialized.Minute "Minute is mapped correctly"
+      Expect.equal time.Second deserialized.Second "Second is mapped correctly"
       
     testCase "records with unions" <| fun _ ->
       let fstRecord = { Id = 1; Union = One }
@@ -186,10 +192,10 @@ let bsonConversions =
 
     testCase "Reading Bson values as DateTime works" <| fun _ ->
     
-      let record = { id = 1; created = DateTime(2017, 10, 15) }
+      let record = { id = 1; created = DateTime(2017, 10, 15, 10, 20, 45) }
       let doc = Bson.serialize record 
       let createdField = Bson.read "created" doc
-      let created1 = createdField.AsDateTime
+      let created1 = Bson.readDate "created" doc
       let created2 = Bson.deserializeField<DateTime> createdField
       Expect.equal created1.Year 2017 "Year is deserialized correctly"
       Expect.equal created2.Year 2017 "Year is deserialized correctly"
@@ -197,6 +203,12 @@ let bsonConversions =
       Expect.equal created2.Month 10 "Month is deserialized correctly"
       Expect.equal created1.Day 15 "Day is deserialized correctly"
       Expect.equal created2.Day 15 "Day is deserialized correctly"
+      Expect.equal created1.Hour 10 "Hour is deserialized correctly"
+      Expect.equal created2.Hour 10 "Hour is deserialized correctly"
+      Expect.equal created1.Minute 20 "Minute is deserialized correctly"
+      Expect.equal created2.Minute 20 "Minute is deserialized correctly"
+      Expect.equal created1.Second 45 "Second is deserialized correctly"
+      Expect.equal created2.Second 45 "Second is deserialized correctly"
       
     testCase "Bson (de)serialization for options works" <| fun _ ->
       let record = { id = 1; generic = Some 1 }

--- a/LiteDB.FSharp/Bson.fs
+++ b/LiteDB.FSharp/Bson.fs
@@ -30,7 +30,10 @@ module Bson =
 
     /// Reads a field from a BsonDocument as DateTime
     let readDate (key: string) (doc: BsonDocument) = 
-        doc.[key].AsDateTime
+        let date = doc.[key].AsDateTime
+        if date.Kind = DateTimeKind.Local 
+        then date.ToUniversalTime() 
+        else date
 
     /// Removes an entry (property) from a `BsonDocument` by the key of that property
     let removeEntryByKey (key:string) (doc: BsonDocument) = 

--- a/LiteDB.FSharp/Json.fs
+++ b/LiteDB.FSharp/Json.fs
@@ -246,7 +246,8 @@ type FSharpJsonConverter() =
         | true, Kind.DateTime ->
             let jsonObject = JObject.Load(reader)
             let dateValue = jsonObject.["$date"].Value<string>()
-            upcast DateTime.Parse(dateValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
+            let date = DateTime.Parse(dateValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
+            upcast (if date.Kind = DateTimeKind.Local then date.ToUniversalTime() else date)
         | true, Kind.Option ->
             let innerType = t.GetGenericArguments().[0]
             let innerType =


### PR DESCRIPTION
fixed #21 

The problem seemed to be internal to the tests only and does not affect actual roundtrip values. this is because reading values directly from `Bson` (what we do in the tests) is not what actually runs with the F# Bson mapper (Entity -> JSON -> Bson -> JSON -> Entity).  

Fixed this by applying the same consistent conversion from `Bson.readDate` as well:
Before
```fs
module Bson = 
    /// Reads a field from a BsonDocument as DateTime
    let readDate (key: string) (doc: BsonDocument) = 
        doc.[key].AsDateTime
```
After
```fs
module Bson = 
    /// Reads a field from a BsonDocument as DateTime
    let readDate (key: string) (doc: BsonDocument) = 
        let date = doc.[key].AsDateTime
        if date.Kind = DateTimeKind.Local 
        then date.ToUniversalTime() 
        else date
```