### PR TITLE
Adds support for records with optional arrays

### DIFF
--- a/LiteDB.FSharp.Tests/Tests.Bson.fs
+++ b/LiteDB.FSharp.Tests/Tests.Bson.fs
@@ -97,10 +97,23 @@ let bsonConversions =
       | otherwise -> fail()
 
     testCase "record with array" <| fun _ ->
-      let record = { id = 1; arr = [| 1 .. 5 |] }
+      let record: RecordWithArray = { id = 1; arr = [| 1 .. 5 |] }
       let doc = Bson.serialize record
       match Bson.deserialize<RecordWithArray> doc with
       | { id = 1; arr = [| 1;2;3;4;5 |] } -> pass()
+      | otherwise -> fail()
+      
+    testCase "record with optional array" <| fun _ ->
+      let recordNone = { id = 1; arr = None }
+      let docNone = Bson.serialize recordNone
+      match Bson.deserialize<RecordWithOptionalArray> docNone with
+      | { id = 1; arr = None } -> pass()
+      | otherwise -> fail()
+      
+      let recordSome = { id = 1; arr = Some([| 1 .. 5 |]) }
+      let docSome = Bson.serialize recordSome
+      match Bson.deserialize<RecordWithOptionalArray> docSome with
+      | { id = 1; arr = Some([| 1;2;3;4;5 |]) } -> pass()
       | otherwise -> fail()
 
     testCase "record with resizeArray" <| fun _ ->

--- a/LiteDB.FSharp.Tests/Tests.Types.fs
+++ b/LiteDB.FSharp.Tests/Tests.Types.fs
@@ -11,6 +11,7 @@ type RecordWithGenericUnion<'t> = { Id: int; GenericUnion: Maybe<'t> }
 type RecordWithDateTime = { id: int; created: DateTime }
 type RecordWithMap = { id : int; map: Map<string, string> }
 type RecordWithArray = { id: int; arr: int[] }
+type RecordWithOptionalArray = { id: int; arr: int[] option }
 type RecordWithResizeArray = { id: int; resizeArray: ResizeArray<int> }
 type RecordWithDecimal = { id: int; number: decimal }
 type RecordWithLong = { id: int; long: int64 }

--- a/LiteDB.FSharp/Bson.fs
+++ b/LiteDB.FSharp/Bson.fs
@@ -73,7 +73,7 @@ module Bson =
     /// Converts a BsonDocument to a typed entity given the document the type of the CLR entity.
     let deserializeByType (entity: BsonDocument) (entityType: Type) =
         let getCollectionElementType (collectionType:Type)=
-            let typeNames = ["FSharpList`1";"IEnumerable`1";"List`"; "List`1"; "IList`1"]
+            let typeNames = ["FSharpList`1";"IEnumerable`1";"List`"; "List`1"; "IList`1"; "FSharpOption`1"]
             let typeName = collectionType.Name
             if List.contains typeName typeNames then
                 collectionType.GetGenericArguments().[0]


### PR DESCRIPTION
We ran into an issue where we wouldn't be able to deserialize a record with an optional array:

```fs
open System
open LiteDB
open LiteDB.FSharp

type ArrayOption =
    { Id : string
      Data: string [] option }

let arrayOptionNone: ArrayOption =
    { Id = Guid.NewGuid().ToString()
      Data = None }
    
let arrayOptionSome: ArrayOption =
    { Id = Guid.NewGuid().ToString()
      Data = Some [| "string" |] }

[<EntryPoint>]
let main argv =
    use db = new LiteDatabase("filename=arrays.db;mode=exclusive", FSharpBsonMapper())

    let arrayOptionCollection = db.GetCollection<ArrayOption>()

    arrayOptionCollection.Insert arrayOptionNone |> ignore
    arrayOptionCollection.Insert arrayOptionSome |> ignore

    let arrayOptions = arrayOptionCollection.FindAll() |> Seq.toArray
    arrayOptions |> Seq.iter (fun x -> (printf "Id: %s" x.Id))
    0
```

This would fail.

The changes made in this PR fix this. I assume it's working not only for arrays but also lists etc., but I tried to keep the tests as close as possible to the existing ones and decided to test it for arrays only.