### PR TITLE
Update README to include LiteDB.FSharp.Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ LiteDB.FSharp comes with a custom `BsonMapper` called `FSharpBsonMapper` that yo
 ```fsharp
 open LiteDB
 open LiteDB.FSharp
+open LiteDB.FSharp.Extensions
 
 let mapper = FSharpBsonMapper()
 use db = new LiteDatabase("simple.db", mapper)


### PR DESCRIPTION
It took me a few minutes of frustration and a trip to the source code to figure out why the following code wasn't recognised
```fsharp
games.fullSearch <@ fun game -> game.Players |> List.contains playerId @>
```
It turns out I needed to add `open LiteDB.FSharp.Extensions` which isn't mentioned at all in the README.

I suggest simply adding `open LiteDB.FSharp.Extensions`  to the initial example would suffice, after all any modern IDE will show you whether it is used or not.